### PR TITLE
[RFR] Fix a bug related to multiple bugzilla ids

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -27,7 +28,8 @@ func main() {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				for _, id := range c.StringSlice("id") {
+				ids := strings.Split(c.StringSlice("id")[0], ",")
+				for _, id := range ids{
 					resp := commands.GetBug(id)
 					for _, bug := range resp.Bugs {
 						data, _ := json.MarshalIndent(bug, "", "\t")


### PR DESCRIPTION
This PR fixes a misbehaviour when multiple bugzilla ids are passed.

Command:
➜  gozilla git:(fix_bug) ✗ ./gozilla bug --id 1000000,120000

Actual result:
```
2020/10/14 22:44:33 https://bugzilla.redhat.com/rest/bug/1000000,120000
```

Expected Result:
```                                          
2020/10/14 22:41:34 https://bugzilla.redhat.com/rest/bug/1000000
{
        "id": 1000000,
        "product": "Fedora",
        "summary": "RFE: improvements to abrt's handling of \"kernel oops\"",
        ...
}
2020/10/14 22:41:41 https://bugzilla.redhat.com/rest/bug/120000
{
        "id": 120000,
        "product": "Fedora",
        ...
}
```