### PR TITLE
Add filtering using keywords and limit results

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,19 @@ OPTIONS:
 2020/05/29 15:46:45 https://bugzilla.redhat.com/rest/bug/1839234
 {"id":1839234,"product":"Fedora","summary":"sqlite-3.32.0 is available","severity":"unspecified"}
 ```
+Search for multiple bug ids
+```shell
+./gozilla bug --id 1839234,1839235
+2020/10/20 08:26:43 https://bugzilla.redhat.com/rest/bug/1839234
+{"id":1839234,"product":"Fedora","summary":"sqlite-3.32.0 is available","severity":"unspecified"}
+2020/10/20 08:26:49 https://bugzilla.redhat.com/rest/bug/1839235
+{"id":1839235,"product":"Red Hat OpenStack","Manage/Unmanage support for CephFS drivers","severity":"medium"}
+```
+Search with keywords
+```shell
+./gozilla bug --keywords=FutureFeature,Triaged --limit=3
+2020/10/20 08:30:05 https://bugzilla.redhat.com/rest/bug?keywords=FutureFeature,Triaged&limit=3
+{"id": 1120141, "product": "Fedora","summary": "perl-Inline-0.62 is available","severity": "unspecified"}
+{"id": 1785814,"product": "Fedora","summary": "svt-av1-0.8.0 is available","severity": "unspecified"}
+{"id": 1512147,"product": "Fedora","summary": "source-to-image-1.3.1 is available","severity": "unspecified",
+```

--- a/commands/bug.go
+++ b/commands/bug.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"regexp"
 
 	"github.com/omaciel/gozilla/bugzilla"
 )
 
+// Version : Fetch the version information of the Bugzilla server.
 func Version() string {
 	resp := bugzilla.BugzillaRequest(
 		"version",
@@ -17,8 +19,16 @@ func Version() string {
 	return resp
 }
 
-func GetBug(id string) Defects {
-	url := fmt.Sprintf("bug/%v", id)
+// GetBug : Fetch a bug/s matching an id or a set of keywords. Also supports adding a limit of results.
+func GetBug(filter, limit string) Defects {
+	var url string
+
+	if matched, _ := regexp.MatchString("^[0-9]+$", filter); matched {
+		url = fmt.Sprintf("bug/%v", filter)
+	} else {
+		url = fmt.Sprintf("bug?keywords=%v&limit=%v", filter, limit)
+	}
+
 	resp := bugzilla.BugzillaRequest(
 		url,
 		nil,
@@ -34,6 +44,7 @@ func GetBug(id string) Defects {
 
 }
 
+// GetBugHistory : Fetch the history of a bug.
 func GetBugHistory(id string) BugHistoryList {
 	url := fmt.Sprintf("bug/%v/history", id)
 	resp := bugzilla.BugzillaRequest(

--- a/commands/bug.go
+++ b/commands/bug.go
@@ -20,13 +20,13 @@ func Version() string {
 }
 
 // GetBug : Fetch a bug/s matching an id or a set of keywords. Also supports adding a limit of results.
-func GetBug(filter, limit string) Defects {
+func GetBug(filter, resultCount string) Defects {
 	var url string
-
+	// if the filter matches digit-only pattern consider it a bug ID else a keyword
 	if matched, _ := regexp.MatchString("^[0-9]+$", filter); matched {
 		url = fmt.Sprintf("bug/%v", filter)
 	} else {
-		url = fmt.Sprintf("bug?keywords=%v&limit=%v", filter, limit)
+		url = fmt.Sprintf("bug?keywords=%v&limit=%v", filter, resultCount)
 	}
 
 	resp := bugzilla.BugzillaRequest(

--- a/main.go
+++ b/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"strings"
 	"encoding/json"
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/omaciel/gozilla/commands"
 
@@ -23,14 +23,32 @@ func main() {
 			Usage: "Fetch a Bugzilla issue by its ID.",
 			Flags: []cli.Flag{
 				&cli.StringSliceFlag{
-					Name:     "id",
-					Required: true,
+					Name: "id",
+				},
+				&cli.StringSliceFlag{
+					Name: "keywords",
+				},
+				&cli.StringSliceFlag{
+					Name: "limit",
 				},
 			},
 			Action: func(c *cli.Context) error {
-				ids := strings.Split(c.StringSlice("id")[0], ",")
-				for _, id := range ids{
-					resp := commands.GetBug(id)
+				var (
+					filters  []string
+					limit string = "5"
+				)
+
+				if c.IsSet("id") {
+					filters = strings.Split(c.StringSlice("id")[0], ",")
+				} else if c.IsSet("keywords") {
+					filters = c.StringSlice("keywords")
+				}
+				if c.IsSet("limit") {
+					limit = c.StringSlice("limit")[0]
+				}
+
+				for _, filter := range filters {
+					resp := commands.GetBug(filter, limit)
 					for _, bug := range resp.Bugs {
 						data, _ := json.MarshalIndent(bug, "", "\t")
 						fmt.Println(string(data))

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
+	"regexp"
 
 	"github.com/omaciel/gozilla/commands"
 
@@ -35,20 +35,21 @@ func main() {
 			Action: func(c *cli.Context) error {
 				var (
 					filters  []string
-					limit string = "5"
+					resultCount string = "5"
 				)
 
 				if c.IsSet("id") {
-					filters = strings.Split(c.StringSlice("id")[0], ",")
+					re := regexp.MustCompile(`[0-9]+\b,{0,1}?`)
+					filters = re.FindAllString(c.String("id"), -1)
 				} else if c.IsSet("keywords") {
 					filters = c.StringSlice("keywords")
 				}
 				if c.IsSet("limit") {
-					limit = c.StringSlice("limit")[0]
+					resultCount = c.StringSlice("limit")[0]
 				}
 
 				for _, filter := range filters {
-					resp := commands.GetBug(filter, limit)
+					resp := commands.GetBug(filter, resultCount)
 					for _, bug := range resp.Bugs {
 						data, _ := json.MarshalIndent(bug, "", "\t")
 						fmt.Println(string(data))


### PR DESCRIPTION
This PR adds support for using keywords to fetch bugs. It also supports the number of results to be returned in the response.

_Usage -_
```
./gozilla --keywords=FutureFeature,Triaged --limit=10
```

Also, added doc strings to some of the functions. go-vet!

P.S. - I feel like this there is a room for improvement in this code, so any suggestions to make it better would be nice.